### PR TITLE
Document cross-agent conflict resolution as a known limit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -195,6 +195,18 @@ Don't mix them up. Wrapping `df` in a Claude Agent container is wasteful (mechan
 
 The framework ships one canonical bot — the **Watcher**. It's a small Node daemon (`listener/src/watcher.ts`) running under PM2 alongside the listener. Uses Bolt + Socket Mode to handle interactive buttons (`Update now`, `Restart listener`, `Ack 24h`, `View logs`) and a `/watcher` slash command. Periodic health checks run on `setInterval`. No AI, no Claude tokens, no Docker per check — but enough Slack runtime to be interactive.
 
+## Cross-agent conflict resolution
+
+The framework does not handle factual disagreements between agents at the framework level. Each agent's memory tiers are private to that agent, and the team directory establishes identity and ownership but not primacy on any factual surface. When two agents reach different conclusions about a shared customer or asset, both flags surface in Slack and the human operator picks the answer.
+
+This is the right shape at the framework's stated audience: small teams, non-overlapping agent domains, single operator in the loop. It works as long as the human can keep up with the cadence of conflicts.
+
+It does NOT scale to teams where multiple agents claim authority over the same factual surface. The canonical failure mode is the retention-vs-sales overlap: a customer flagged as at-risk by the retention agent and as ready-to-cross-sell by the sales agent, both flags surfacing the same morning, no merge rule beyond operator judgment. At small scale this is one Slack message. At ten conflicts a day across five overlapping agents this is the operator's full-time job.
+
+Operators who hit this scale can adopt a per-install convention without framework support. One example pattern is the OOS file format from OTP (https://orgtp.com/protocol), which expresses cross-agent merge rules as a markdown file with structured claims. A drafted example for a hypothetical 5-agent ginnie-agents install, with companion notes on what would change in the runner to load it as a ninth layer in the system prompt composition, lives at https://github.com/david-steel/OTP/tree/main/content/oos-drafts. That repo has no runtime relationship to ginnie-agents; the file format lives in the operator's own repo and the runtime sync at orgtp.com is optional.
+
+Whether the framework should grow this layer into core or stay where it is, is a real design question. For now, the framework's stance is: not handled at framework level, scope acknowledged, escalation path is human-in-the-Slack-loop.
+
 ## What's deliberately NOT in this framework
 
 - **Multi-LLM**: Claude Code + Max only. No OpenAI, no Gemini, no API SDK.


### PR DESCRIPTION
Per the discussion in #1, this adds an `ARCHITECTURE.md` section that names the cross-agent conflict resolution stance explicitly: not handled at framework level, escalation through Slack to the operator, breaks at scale where multiple agents claim authority over the same factual surface (retention-vs-sales).

Includes a pointer to one per-install pattern operators can adopt without framework support (OTP's OOS file format) and the drafted example written for ginnie-agents specifically. The OOS pattern is referenced as one example, not as a recommendation. The design question of whether the framework should grow this layer into core is left open.

No code changes; documentation only.

Companion artifacts (in OTP's repo, not this PR):
- Drafted OOS file for a hypothetical 5-agent ginnie-agents install: https://github.com/david-steel/OTP/blob/main/content/oos-drafts/ginnie-agents.oos.md
- Concrete integration notes (what would change in the runner to load it as a ninth layer): https://github.com/david-steel/OTP/blob/main/content/oos-drafts/ginnie-agents-INTEGRATION.md

Both are MIT-licensed to match this repo. No commitment to adopt is implied.